### PR TITLE
feat: add OpportunityMatchStatusType and statusMatch to ApiOpportunityGetList

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -8,7 +8,7 @@ import { OptionItem } from "./option";
 import { PreferredCommunicationType } from "./person";
 import { ProfileVolunteeringType } from "./profile";
 import { ApiAvailability } from "./time";
-import { VolunteerStateTypeType } from "./volunteer";
+import { VolunteerStateMatchType, VolunteerStateTypeType } from "./volunteer";
 
 export const { REGULAR_ACCOMPANYING, ...OpportunityType } =
   ProfileVolunteeringType;
@@ -128,7 +128,7 @@ export interface ApiOpportunityGetList {
   category: OptionById;
   volunteerType: VolunteerStateTypeType;
   statusOpportunity: OpportunityStatusType;
-  statusMatch: OpportunityMatchStatusType;
+  statusMatch: VolunteerStateMatchType;
   createdAt: Date;
   activities: OptionById[];
   languages: ApiLanguage[];

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -37,6 +37,13 @@ export enum OpportunityMatchStatus {
   UNMATCHED = "opp-unmatched",
 }
 
+export enum OpportunityMatchStatusType {
+  NO_MATCHES = "vol-no-matches",
+  PENDING_MATCH = "vol-pending-match",
+  MATCHED = "vol-matched",
+  PAST = "vol-past",
+}
+
 export enum OpportunityVolunteerStatusType {
   PENDING = "opp-pending",
   MATCHED = "opp-matched",
@@ -121,6 +128,7 @@ export interface ApiOpportunityGetList {
   category: OptionById;
   volunteerType: VolunteerStateTypeType;
   statusOpportunity: OpportunityStatusType;
+  statusMatch: OpportunityMatchStatusType;
   createdAt: Date;
   activities: OptionById[];
   languages: ApiLanguage[];

--- a/src/types/api/volunteer.ts
+++ b/src/types/api/volunteer.ts
@@ -115,6 +115,7 @@ export enum VolunteerStateMatchType {
   PENDING_MATCH = "vol-pending-match",
   MATCHED = "vol-matched",
   NEEDS_REMATCH = "vol-needs-rematch",
+  PAST = "vol-past",
 }
 
 export const VolunteerCommunicationType = PreferredCommunicationType;


### PR DESCRIPTION
## Summary

- Add `OpportunityMatchStatusType` enum (`vol-no-matches`, `vol-pending-match`, `vol-matched`, `vol-past`)
- Add `statusMatch: OpportunityMatchStatusType` to `ApiOpportunityGetList` (and by extension `ApiOpportunityGet`)

## Test plan

- [ ] `OpportunityMatchStatusType` is importable from the SDK
- [ ] `ApiOpportunityGetList.statusMatch` type-checks correctly
- [ ] Existing consumers of `ApiOpportunityGetList` compile (may need `statusMatch` added where they construct the object)

## Depends on
- need4deed-org/be#413 (adds the column and derives the value)

## Closes
#88

🤖 Generated with [Claude Code](https://claude.com/claude-code)