### PR TITLE
ci: auto-publish to npm on every merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,22 @@
 name: Publish on Merge to Main
 
 on:
-  workflow_dispatch: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org/"
@@ -20,10 +24,20 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Bump version
-        run: yarn version --patch --no-git-tag-version
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version and commit
+        run: |
+          yarn version --patch --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          git add package.json
+          git commit -m "chore: bump version to $VERSION [skip ci]"
+          git push
 
       - name: Publish to npm
-        run: yarn publish:npm
+        run: yarn publish --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

The publish workflow was `workflow_dispatch` only (manual trigger), which meant someone had to remember to go to GitHub Actions and click run after every merge. The programmer was working around this by publishing locally instead.

## Changes

- **Auto-trigger** on every push to `main` (plus keep `workflow_dispatch` as manual fallback)
- **Commit version bump back to repo** — previously `--no-git-tag-version` changed `package.json` only in the CI runner, so the repo's version was always behind npm. Now the bumped `package.json` is committed and pushed with `[skip ci]` to prevent an infinite loop
- **Fix broken script name** — `yarn publish:npm` doesn't exist; changed to `yarn publish --non-interactive` (matches the `publish` script in `package.json`)

## Result

After merging any PR into `main`, the workflow runs automatically, bumps the patch version, commits it, and publishes to npmjs.com. No manual steps needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)