### PR TITLE
feat: add statusVaccinationDate, statusCGCApplicationDate, statusCGCDate to ApiVolunteerGet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.75",
+  "version": "0.0.82",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/volunteer.ts
+++ b/src/types/api/volunteer.ts
@@ -148,6 +148,9 @@ export interface ApiVolunteerGet {
   updatedAt: Date;
   goodConductCertificate: DocumentStatusType;
   measlesVaccination: DocumentStatusType;
+  statusVaccinationDate: Date | null;
+  statusCGCApplicationDate: Date | null;
+  statusCGCDate: Date | null;
   infoAbout: string;
   infoExperience: string;
   timelineLogs: TimedText[];


### PR DESCRIPTION
## Summary

- Adds `statusVaccinationDate`, `statusCGCApplicationDate`, `statusCGCDate` (`Date | null`) to `ApiVolunteerGet`
- Required by BE https://github.com/need4deed-org/be/issues/481 and FE https://github.com/need4deed-org/fe/issues/508

## Test plan

- [ ] FE compiles without errors after updating `need4deed-sdk` to the published version
- [ ] `VolunteerPatchBodyData` (extends `Partial<ApiVolunteerGet>`) does not need changes — dates are read-only from FE perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)