### PR TITLE
feat: add SMS to PreferredCommunicationType and VIDEO_CALL to ContactMethodType

### DIFF
--- a/src/types/api/communication.ts
+++ b/src/types/api/communication.ts
@@ -13,6 +13,7 @@ export enum ContactMethodType {
   SIGNAL = "signal",
   SMS = "sms",
   VOICENOTE = "voicenote",
+  VIDEO_CALL = "video-call",
 }
 
 export enum CommunicationType {

--- a/src/types/api/person.ts
+++ b/src/types/api/person.ts
@@ -5,6 +5,7 @@ export enum PreferredCommunicationType {
   MOBILE_PHONE = "mobilePhone",
   WHATSAPP = "whatsapp",
   TELEGRAM = "telegram",
+  SMS = "sms",
 }
 
 export interface ApiPersonGet {


### PR DESCRIPTION
## Summary
- Adds `SMS = "sms"` to `PreferredCommunicationType` — so volunteers can indicate SMS as a preferred contact method
- Adds `VIDEO_CALL = "video-call"` to `ContactMethodType` — so briefings and other communications can be logged as video calls

## Related issues
- https://github.com/need4deed-org/sdk/issues/95
- https://github.com/need4deed-org/sdk/issues/96
- https://github.com/need4deed-org/fe/issues/491
- https://github.com/need4deed-org/fe/issues/521

## Test plan
- [ ] FE: volunteer contact details form shows SMS as a preferred contact option
- [ ] FE: communication tracker shows "Video call" in contact method dropdown when contact type is a call

🤖 Generated with [Claude Code](https://claude.com/claude-code)