### PR TITLE
feat: add statusMatch and statusCommunication to ApiVolunteerGetList

### DIFF
--- a/src/types/api/volunteer.ts
+++ b/src/types/api/volunteer.ts
@@ -121,6 +121,8 @@ export interface ApiVolunteerGetList {
   id: number;
   statusEngagement: VolunteerStateEngagementType;
   statusType: VolunteerStateTypeType;
+  statusMatch?: VolunteerStateMatchType;
+  statusCommunication?: VolunteerStateCommunicationType;
   name: string;
   avatarUrl: string;
   languages: ApiLanguage[];


### PR DESCRIPTION
## Summary
Adds `statusMatch?: VolunteerStateMatchType` and `statusCommunication?: VolunteerStateCommunicationType` to `ApiVolunteerGetList` so the volunteer list endpoint can expose these fields.

## Related
- Closes https://github.com/need4deed-org/sdk/issues/98
- FE issue: https://github.com/need4deed-org/fe/issues/423

🤖 Generated with [Claude Code](https://claude.com/claude-code)