### PR TITLE
fix(#87): add INACTIVE to OpportunityStatusType enum

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -27,6 +27,7 @@ export enum OpportunityStatusType {
   NEW = "opp-new",
   SEARCHING = "opp-searching",
   ACTIVE = "opp-active",
+  INACTIVE = "opp-inactive",
   PAST = "opp-past",
 }
 


### PR DESCRIPTION
## Summary

- Adds `INACTIVE = "opp-inactive"` to the `OpportunityStatusType` enum in `src/types/api/opportunity.ts`

## Motivation

The BE migration `1777284365646-add-inactive-to-opp-status.ts` added `opp-inactive` to the `opportunity_status_enum` PostgreSQL type, but the SDK enum was never updated. This causes a 400 "Validation failed" error when the dashboard tries to set an opportunity status to Inactive.

## Related

- Closes https://github.com/need4deed-org/sdk/issues/87
- Unblocks https://github.com/need4deed-org/be/issues/438
- Unblocks https://github.com/need4deed-org/fe/issues/459

🤖 Generated with [Claude Code](https://claude.com/claude-code)