### PR TITLE
Agent self-registration contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+dev.*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.102",
+  "version": "0.0.103",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.99",
+  "version": "0.0.100",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.100",
+  "version": "0.0.101",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.101",
+  "version": "0.0.102",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -4,4 +4,9 @@ export enum Endpoint {
   TESTIMONIAL = "/testimonial",
   VOLUNTEER = "/volunteer",
   OPTION = "/option",
+  AGENT = "/agent",
+  // Sub-path prefix, mounted under AGENT (mirrors the backend's
+  // `register(agentRegisterRoutes, { prefix: REGISTER })`). Compose as
+  // `Endpoint.AGENT + Endpoint.REGISTER` -> "/agent/register".
+  REGISTER = "/register",
 }

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -128,3 +128,56 @@ interface AgentPatch {
   districtId: number;
 }
 export type ApiAgentPatch = VoidableProps<AgentPatch>;
+
+// --- Agent self-registration ---------------------------------------------
+// An authenticated AGENT user (already created + email-verified via POST /user)
+// either JOINs an existing agent or CREATEs a new one through POST /agent/register.
+//
+// NOTE: the write field names below (`info`, `languages: number[]`) follow the
+// registration write contract and intentionally differ from ApiAgentPatch
+// (`about`, `languages: OptionById[]`). Do not "align" them — they map to
+// different backend handlers.
+
+export interface ApiAgentRegisterNew {
+  title: string;
+  type?: AgentType;
+  info?: string;
+  website?: string;
+  services?: AgentServiceType[];
+  addressStreet?: string;
+  addressPostcode?: string;
+  districtId?: number;
+  languages?: number[];
+}
+
+export type ApiAgentRegister =
+  | { agentId: number }
+  | { agent: ApiAgentRegisterNew };
+
+export enum AgentMembershipStatus {
+  ACTIVE = "active",
+  PENDING = "pending",
+}
+
+export interface ApiAgentRegisterResponse {
+  agentId: number;
+  membershipStatus: AgentMembershipStatus;
+}
+
+// Returned with HTTP 409 when CREATE hits the unique-title constraint, so the
+// client can offer to JOIN the existing agent instead of minting a duplicate.
+export interface ApiAgentTitleConflict {
+  conflict: "title";
+  agentId: number;
+}
+
+// A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
+// joins that did not pass domain-match (membershipStatus === PENDING).
+export interface ApiAgentMembership {
+  id: number;
+  agentId: number;
+  agentTitle: string;
+  person: ApiPersonGet;
+  role: AgentRoleType;
+  status: AgentMembershipStatus;
+}

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -1,3 +1,4 @@
+import { Lang } from "../core";
 import { VoidableProps } from "../utils";
 
 export enum UserRole {
@@ -6,6 +7,19 @@ export enum UserRole {
   AGENT = "agent",
   VOLUNTEER = "volunteer",
   ADMIN = "admin",
+}
+
+export interface ApiUserPost {
+  email: string;
+  password: string;
+  role: UserRole;
+  language: Lang;
+  person: {
+    id?: number;
+    firstName?: string;
+    middleName?: string;
+    lastName?: string;
+  };
 }
 
 interface UserGet {

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -13,7 +13,7 @@ export interface ApiUserPost {
   email: string;
   password: string;
   role: UserRole;
-  language: Lang;
+  language?: Lang;
   person: {
     id?: number;
     firstName?: string;


### PR DESCRIPTION
Adds the contract for agent self-registration (consumed by BE `591-agent-self-registration` and FE `arturas/agent-self-registration`). Published as **0.0.103**.

## What
- `endpoints.ts`: `Endpoint.AGENT` + composable `Endpoint.REGISTER` (mounts under `/agent`, mirroring the backend prefix).
- `agent.ts`:
  - `ApiAgentRegisterNew` and `ApiAgentRegister = { agentId } | { agent }` (join vs create).
  - `AgentMembershipStatus` (`active` | `pending`), `ApiAgentRegisterResponse`.
  - `ApiAgentTitleConflict` (409 → offer join), `ApiAgentMembership` (moderation list).

## Notes
- The registration write fields (`info`, `languages: number[]`) intentionally differ from `ApiAgentPatch` (`about`, `languages: OptionById[]`) — they map to different backend handlers; documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)