### PR TITLE
feat(opportunity): add ApiAgentOpportunity contract

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -195,3 +195,30 @@ export interface OpportunityVolunteer {
 export interface ApiOpportunityVolunteerGet extends OpportunityVolunteer {
   title: string;
 }
+
+/**
+ * A volunteer linked to an opportunity, as surfaced on an agent's opportunity
+ * list. Person fields (`name`, `avatarUrl`) are PII-masked per caller role by
+ * the API, so they may be absent or redacted.
+ */
+export interface ApiAgentOpportunityVolunteer {
+  id: number;
+  volunteerId: number;
+  status: OpportunityVolunteerStatusType;
+  name?: string;
+  avatarUrl?: string;
+}
+
+/**
+ * One of an agent's opportunities with the volunteers linked to it. Response
+ * item of `GET /agent/:id/opportunity-linked`.
+ */
+export interface ApiAgentOpportunity {
+  id: Id;
+  title: string;
+  statusOpportunity: OpportunityStatusType;
+  statusMatch: OpportunityMatchStatusType;
+  numberOfVolunteers: number;
+  createdAt: Date;
+  volunteers: ApiAgentOpportunityVolunteer[];
+}


### PR DESCRIPTION
## What

Adds the response contract for `GET /agent/:id/opportunity-linked`:

- `ApiAgentOpportunity` — one of an agent's opportunities (`id`, `title`, `statusOpportunity`, `statusMatch`, `numberOfVolunteers`, `createdAt`) plus `volunteers`.
- `ApiAgentOpportunityVolunteer` — a volunteer linked to that opportunity (`id`, `volunteerId`, `status`, optional `name`/`avatarUrl`).

## Why

The BE endpoint currently returns the raw TypeORM entity with no response schema (identity passthrough). This gives it a real, masked-PII-aware contract so the BE can serialize through a DTO + AJV schema instead of the whole entity graph (need4deed-org/be PR #667 review, finding #2).

Person fields on the linked volunteers are PII-masked per caller role by the API, hence optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
