### PR TITLE
feat(agent): add ApiAgentAddressConflict to register contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.104",
+  "version": "0.0.105",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -171,6 +171,18 @@ export interface ApiAgentTitleConflict {
   agentId: number;
 }
 
+// Returned with HTTP 409 when CREATE's street+postcode already resolve to an
+// existing agent (same getAgentByAddress matcher as POST /opportunity/legacy),
+// so the client can offer to JOIN it instead of minting a duplicate.
+export interface ApiAgentAddressConflict {
+  conflict: "address";
+  agentId: number;
+}
+
+export type ApiAgentRegisterConflict =
+  | ApiAgentTitleConflict
+  | ApiAgentAddressConflict;
+
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).
 export interface ApiAgentMembership {


### PR DESCRIPTION
## What

Adds the `address` conflict shape to the agent self-registration contract:

- `ApiAgentAddressConflict` — `{ conflict: "address"; agentId }`
- `ApiAgentRegisterConflict = ApiAgentTitleConflict | ApiAgentAddressConflict`

`ApiAgentTitleConflict` is unchanged (additive, non-breaking).

## Why

`POST /agent/register` (CREATE) now dedups on address too: if the submitted `street`+`postcode` already resolve to an existing agent — via the same `getAgentByAddress` matcher `POST /opportunity/legacy` uses — it returns **409 + `agentId`** so the client can offer to JOIN instead of minting a duplicate (need4deed-org/be, #591/#601 follow-up).

> Note: the BE doesn't import this type (the 409 is validated against the route's local AJV schema), so no BE version bump is required — this just keeps the published contract / Swagger in sync for the FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
