### PR TITLE
feat(trusted-domain): agent-registration domain allowlist contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -15,5 +15,6 @@ export * from "./person";
 export * from "./profile";
 export * from "./testimonial";
 export * from "./time";
+export * from "./trusted-domain";
 export * from "./user";
 export * from "./volunteer";

--- a/src/types/api/trusted-domain.ts
+++ b/src/types/api/trusted-domain.ts
@@ -1,0 +1,17 @@
+// Email-domain allowlist for agent self-registration. A registrant whose email
+// domain is on this list is treated as belonging to a known RAC organisation —
+// so a brand-new representative (whose org has no existing member yet) can still
+// register, and a join auto-approves to ACTIVE. Managed by COORDINATOR/ADMIN.
+
+export interface ApiTrustedDomain {
+  id: number;
+  domain: string;
+}
+
+export interface ApiTrustedDomainPost {
+  domain: string;
+}
+
+export interface ApiTrustedDomainPatch {
+  domain: string;
+}


### PR DESCRIPTION
## What

Adds the contract for the agent-registration **trusted email-domain allowlist**:

- `ApiTrustedDomain { id, domain }`
- `ApiTrustedDomainPost { domain }`
- `ApiTrustedDomainPatch { domain }`

## Why

A brand-new agent representative currently can't self-register: the domain gate (`POST /user` for `role: agent`, and `resolveJoinStatus`) only passes when an **existing** member already shares the email domain — so the first rep of an org not yet in the system is rejected. The BE will fall back to this managed allowlist; these types back the `GET/POST/PATCH/DELETE /trusted-domain` CRUD (COORDINATOR/ADMIN) and the registration check.

need4deed-org/be #591/#601 follow-up. Built on `main` (now incl. #126 `ApiAgentAddressConflict`), so the next publish is forward-only — **next version ≥ 0.0.106** (`0.0.105` is taken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
