### PR TITLE
feat(opportunity): add volunteerNames to ApiOpportunityGetList

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -144,6 +144,11 @@ export interface ApiOpportunityGetList {
   location: OptionById[];
   accompanyingDetails: ApiOpportunityAccompanyingDetails;
   agentTitle: string;
+  // Names of the volunteers matched (m2m) to the opportunity (named
+  // `volunteerNames`, not `volunteers`, to avoid implying volunteer objects).
+  // PII-masked per caller role by the API. Populated on GET /opportunity
+  // (list); optional so the interfaces extending this base needn't supply it.
+  volunteerNames?: string[];
 }
 
 export interface ApiOpportunityGet extends ApiOpportunityGetList {


### PR DESCRIPTION
## What

Adds `volunteerNames?: string[]` to `ApiOpportunityGetList` — names of the volunteers matched (m2m) to an opportunity, surfaced on `GET /opportunity` (list).

- Named **`volunteerNames`** (not `volunteers`) to avoid implying volunteer objects.
- **Optional** on the shared base so `ApiOpportunityGet` and `ApiVolunteerOpportunityGetList` (which extend it) needn't supply it — only the list DTO populates it.
- PII-masked per caller role by the API (`opportunityVolunteer.volunteer.person.name`).

need4deed-org/be follow-up. Next publish ≥ `0.0.107`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
