### PR TITLE
feat(activity-log): add ActivityLog SDK types v0.0.111

### DIFF
--- a/.claude/shared-rules.md
+++ b/.claude/shared-rules.md
@@ -1,0 +1,44 @@
+# Shared project rules
+
+These rules apply to **all three repos** (`be`, `fe`, `sdk`). This file is synced from the
+org `.github` repo — do not edit it inside a downstream repo; change it at the source and let
+the sync open a PR. Repo-specific rules live below the import in each repo's own `CLAUDE.md`.
+
+## API changes go through the SDK contract first
+
+The `sdk` is the single source of truth for the API contract. Any change to the API surface
+(endpoints, request/response shapes, types, error codes) **MUST** follow this order:
+
+1. Define or update the contract in the `sdk` repo first.
+2. Publish the new SDK version to npm.
+3. Only then update `be` and `fe` to consume the change.
+
+**IMPORTANT:** `be` and `fe` MUST depend on the SDK as published on **npmjs.com** — never on the
+local `sdk` checkout or a sibling folder. Do not use `file:../sdk`, `npm link`, workspace or
+`link:` references, or any other local linking for the SDK dependency. Pin to a version that is
+actually published. If the version you need isn't on npmjs.com yet, the work is **not ready** to
+land in `be`/`fe` — finish and publish the SDK first.
+
+Do not implement or "stub" an API change in `be` or `fe` ahead of the contract. If the contract is
+missing, wrong, or incomplete, fix it in `sdk` and publish — never work around it locally.
+
+Allways make sure all API related issues are based on the latest dependency "need4deed-sdk".
+
+## Reuse before you create
+
+Before adding any new util, helper, hook, component, or shared function, **first search** the
+codebase (and the SDK) for something that already does the job. Prefer reusing or extending
+existing code over writing a near-duplicate. If nothing fits and you must add a new one, state
+briefly why the existing options didn't work.
+
+## Be conservative with database schema changes
+
+Before altering the database schema:
+
+- Confirm the change is **absolutely necessary** and cannot reasonably be solved without touching
+  the schema.
+- Confirm it is **semantically correct** — names and structure must match existing modeling
+  conventions and clearly express what the data represents.
+
+Surface the proposed change and your reasoning *before* writing a migration. Schema changes are
+deliberate decisions, not incidental side effects of a feature.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+@.claude/shared-rules.md
+
+# CLAUDE rules for SDK

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.106",
+  "version": "0.0.107",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.108",
+  "version": "0.0.109",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.109",
+  "version": "0.0.110",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.110",
+  "version": "0.0.111",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/activity-log.ts
+++ b/src/types/api/activity-log.ts
@@ -1,0 +1,18 @@
+export interface ApiActivityLogEntry {
+  id: number;
+  date: Date;
+  hours: number;
+}
+
+export interface ApiActivityLogGet {
+  data: ApiActivityLogEntry[];
+  totalHours: number;
+  count: number;
+}
+
+export interface ApiActivityLogPost {
+  date: Date;
+  hours: number;
+}
+
+export type ApiActivityLogPatch = Partial<ApiActivityLogPost>;

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./accompanying";
+export * from "./activity-log";
 export * from "./agent";
 export * from "./appreciation";
 export * from "./comment";

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -83,14 +83,16 @@ export interface OpportunityFormData {
 
 export interface OpportunityLegacyFormDataProps {
   title: string;
-  rac_email: string;
-  rac_full_name: string;
-  rac_phone: string;
-  rac_address: string;
-  rac_plz: string;
+  rac_email?: string;
+  rac_full_name?: string;
+  rac_phone?: string;
+  rac_address?: string;
+  rac_plz?: string;
+  agent_id?: number;
+  submitted_by_id?: number;
   opportunity_type: "accompanying" | "volunteering";
-  accomp_address: string;
-  accomp_postcode: string;
+  accomp_address?: string;
+  accomp_postcode?: string;
   accomp_datetime?: string;
   accomp_name?: string;
   accomp_phone?: string;
@@ -111,6 +113,13 @@ export interface OpportunityLegacyFormDataProps {
 }
 export type OpportunityLegacyFormData =
   VoidableUndefined<OpportunityLegacyFormDataProps>;
+
+export type OpportunityFormDataWithAgentSubmitter = VoidableUndefined<
+  Omit<
+    OpportunityFormData,
+    "rac_email" | "rac_full_name" | "rac_phone" | "rac_address" | "rac_plz"
+  >
+>;
 
 export interface ApiOpportunityAgent {
   id: number;

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -116,7 +116,7 @@ export type OpportunityLegacyFormData =
 
 export type OpportunityFormDataWithAgentSubmitter = VoidableUndefined<
   Omit<
-    OpportunityFormData,
+    OpportunityLegacyFormDataProps,
     "rac_email" | "rac_full_name" | "rac_phone" | "rac_address" | "rac_plz"
   >
 >;

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -153,6 +153,11 @@ export interface ApiOpportunityGetList {
   location: OptionById[];
   accompanyingDetails: ApiOpportunityAccompanyingDetails;
   agentTitle: string;
+  // Names of the volunteers matched (m2m) to the opportunity (named
+  // `volunteerNames`, not `volunteers`, to avoid implying volunteer objects).
+  // PII-masked per caller role by the API. Populated on GET /opportunity
+  // (list); optional so the interfaces extending this base needn't supply it.
+  volunteerNames?: string[];
 }
 
 export interface ApiOpportunityGet extends ApiOpportunityGetList {


### PR DESCRIPTION
## Summary

Adds four types for the volunteer session hours tracking feature:

- `ApiActivityLogEntry` — single log entry (`id`, `date`, `hours`)
- `ApiActivityLogGet` — list response (`data`, `totalHours`, `count`)
- `ApiActivityLogPost` — create body (`date`, `hours`)
- `ApiActivityLogPatch` — update body (partial of Post)

## Related
- need4deed-org/be#679
- need4deed-org/fe#577

🤖 Generated with [Claude Code](https://claude.com/claude-code)