### PR TITLE
feat(comment): replace taggedPersonIds with taggedPersons carrying readAt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/comment.ts
+++ b/src/types/api/comment.ts
@@ -1,3 +1,8 @@
+export interface ApiCommentTaggedPerson {
+  id: number;
+  readAt: Date | null;
+}
+
 export interface ApiComment {
   id: number;
   content: string;
@@ -5,5 +10,5 @@ export interface ApiComment {
   entityType?: string;
   authorName: string;
   timestamp: Date;
-  taggedPersonIds: number[];
+  taggedPersons: ApiCommentTaggedPerson[];
 }


### PR DESCRIPTION
## Summary

- Adds `ApiCommentTaggedPerson { id: number; readAt: Date | null }` interface
- Replaces `ApiComment.taggedPersonIds: number[]` with `taggedPersons: ApiCommentTaggedPerson[]`

This is a **breaking change**. Consumers currently accessing `taggedPersonIds` must migrate to `taggedPersons.map(p => p.id)`.

Needed by be to expose `comment_person.read_at` and the mark-as-read endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)