### PR TITLE
feat(opportunity): add agentId to ApiOpportunityGetList

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/comment.ts
+++ b/src/types/api/comment.ts
@@ -1,3 +1,8 @@
+export interface ApiCommentTaggedPerson {
+  id: number;
+  readAt: Date | null;
+}
+
 export interface ApiComment {
   id: number;
   content: string;
@@ -5,5 +10,5 @@ export interface ApiComment {
   entityType?: string;
   authorName: string;
   timestamp: Date;
-  taggedPersonIds: number[];
+  taggedPersons: ApiCommentTaggedPerson[];
 }

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -153,6 +153,7 @@ export interface ApiOpportunityGetList {
   location: OptionById[];
   accompanyingDetails: ApiOpportunityAccompanyingDetails;
   agentTitle: string;
+  agentId: number;
   // Names of the volunteers matched (m2m) to the opportunity (named
   // `volunteerNames`, not `volunteers`, to avoid implying volunteer objects).
   // PII-masked per caller role by the API. Populated on GET /opportunity


### PR DESCRIPTION
## Summary

Adds `agentId: number` to `ApiOpportunityGetList` alongside the existing `agentTitle`.

Needed by fe#570 (NGO view: restrict other orgs' opportunity columns to title + location). The FE compares each row's `agentId` against the authenticated user's agent to decide which columns to show — no new endpoint or query param required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)