### PR TITLE
fix(opportunity): agentId is number | null, not number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.111",
+  "version": "0.0.112",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/comment.ts
+++ b/src/types/api/comment.ts
@@ -1,3 +1,8 @@
+export interface ApiCommentTaggedPerson {
+  id: number;
+  readAt: Date | null;
+}
+
 export interface ApiComment {
   id: number;
   content: string;
@@ -5,5 +10,5 @@ export interface ApiComment {
   entityType?: string;
   authorName: string;
   timestamp: Date;
-  taggedPersonIds: number[];
+  taggedPersons: ApiCommentTaggedPerson[];
 }

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -153,7 +153,7 @@ export interface ApiOpportunityGetList {
   location: OptionById[];
   accompanyingDetails: ApiOpportunityAccompanyingDetails;
   agentTitle: string;
-  agentId: number;
+  agentId: number | null;
   // Names of the volunteers matched (m2m) to the opportunity (named
   // `volunteerNames`, not `volunteers`, to avoid implying volunteer objects).
   // PII-masked per caller role by the API. Populated on GET /opportunity

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -153,6 +153,7 @@ export interface ApiOpportunityGetList {
   location: OptionById[];
   accompanyingDetails: ApiOpportunityAccompanyingDetails;
   agentTitle: string;
+  agentId: number;
   // Names of the volunteers matched (m2m) to the opportunity (named
   // `volunteerNames`, not `volunteers`, to avoid implying volunteer objects).
   // PII-masked per caller role by the API. Populated on GET /opportunity


### PR DESCRIPTION
Fixes type introduced in #134. An opportunity can have no linked agent (legacy/imported rows), so `agentId` must be `number | null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)