### PR TITLE
feat(user): add optional agentId to ApiUserGet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.114",
+  "version": "0.0.115",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -33,6 +33,7 @@ interface UserGet {
   avatarUrl: string;
   isoCode: string;
   timezone: string;
+  agentId?: number;
 }
 
 export type ApiUserGet = VoidableProps<UserGet, "avatarUrl" | "personId">;


### PR DESCRIPTION
## Summary

- Adds `agentId?: number` to `UserGet` / `ApiUserGet`
- Formalises the field already returned by `GET /user/me` since be#692 was merged
- Bumps to `0.0.115`

## Context

be#692 added `agentId` to the `/user/me` response but worked around the missing SDK type with a local `ApiUserGet & { agentId?: number }` intersection and a manual patch to `sdk-types.json`. This PR brings the SDK contract into line so `be` and `fe` can consume the field through the proper type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)