### PR TITLE
feat(opportunity): add OpportunityLegacyType enum for legacy form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.115",
+  "version": "0.0.117",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -17,6 +17,11 @@ export type OpportunityType = Exclude<
   ProfileVolunteeringType.REGULAR_ACCOMPANYING
 >;
 
+export enum OpportunityLegacyType {
+  VOLUNTEERING = "volunteering",
+  ACCOMPANYING = "accompanying",
+}
+
 export enum TranslatedIntoType {
   DEUTSCHE = "deutsche",
   ENGLISH_OK = "englishOk",
@@ -90,7 +95,7 @@ export interface OpportunityLegacyFormDataProps {
   rac_plz?: string;
   agent_id?: number;
   submitted_by_id?: number;
-  opportunity_type: "accompanying" | "volunteering";
+  opportunity_type: OpportunityLegacyType;
   accomp_address?: string;
   accomp_postcode?: string;
   accomp_datetime?: string;


### PR DESCRIPTION
## Summary

- Add `OpportunityLegacyType` enum (`VOLUNTEERING = "volunteering"`, `ACCOMPANYING = "accompanying"`) to replace the bare string union in `OpportunityLegacyFormDataProps.opportunity_type`
- Bump to `0.0.117`

The legacy form API predates `ProfileVolunteeringType` and uses different string values (`"volunteering"` vs `"regular"`). The bare union forced consumers to compare against magic strings. The new enum gives a named constant to import.

## Test plan

- [ ] `yarn build` passes in SDK
- [ ] `be` upgraded to `0.0.117` — typecheck and 419 tests pass
- [ ] `fe` can import `OpportunityLegacyType` from `need4deed-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)