### PR TITLE
feat(post): add Post API types

### DIFF
--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -11,6 +11,7 @@ export * from "./language";
 export * from "./location";
 export * from "./opportunity";
 export * from "./option";
+export * from "./post";
 export * from "./organization";
 export * from "./person";
 export * from "./profile";

--- a/src/types/api/post.ts
+++ b/src/types/api/post.ts
@@ -1,0 +1,30 @@
+import { VoidableProps } from "../utils";
+
+export interface ApiPostPerson {
+  id: number;
+  fullName: string;
+  avatarUrl?: string;
+}
+
+export interface ApiPostLinkedOpportunity {
+  id: number;
+  title: string;
+}
+
+export interface ApiPostGet {
+  id: number;
+  text: string;
+  author: ApiPostPerson;
+  agentId: number | null;
+  taggedPersons: ApiPostPerson[];
+  linkedOpportunities: ApiPostLinkedOpportunity[];
+  createdAt: Date;
+}
+
+export interface ApiPostPost {
+  text: string;
+  taggedPersonIds?: number[];
+  linkedOpportunityIds?: number[];
+}
+
+export type ApiPostPatch = VoidableProps<ApiPostPost>;


### PR DESCRIPTION
## Summary
- Adds `ApiPostPerson`, `ApiPostLinkedOpportunity`, `ApiPostGet`, `ApiPostPost`, `ApiPostPatch` types for the Post feed feature (need4deed-org/be#680)
- Exports from `types/api/index.ts`

## Test plan
- [ ] `yarn typecheck` passes