### PR TITLE
chore: bump version to 0.0.123

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Merges the version bump that was published to npm as 0.0.123 but never landed on main.

The `latest` dist-tag will be fixed to point to 0.0.123 after this merges.