### PR TITLE
fix(ci): use PAT for gh pr create in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Open version bump PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           BRANCH="chore/version-bump-$VERSION"


### PR DESCRIPTION
`GITHUB_TOKEN` cannot create pull requests due to the org-level policy "Allow GitHub Actions to create and approve pull requests" being disabled. The org already has `secrets.PAT` for exactly this purpose (used in all infra workflows). Swaps the token for the `gh pr create` / `gh pr merge` step.