### PR TITLE
fix(ci): trigger publish workflow on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish on Merge to Main
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `push: branches: [main]` trigger so the workflow runs automatically on every merge to main. Keeps `workflow_dispatch` for manual runs.