### PR TITLE
fix: add title to ApiOpportunityPatch

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -177,6 +177,7 @@ export interface ApiOpportunityGet extends ApiOpportunityGetList {
 export type ApiOpportunityLean = Omit<ApiOpportunityGet, "comments">;
 
 export type ApiOpportunityPatch = VoidableProps<{
+  title: string;
   statusOpportunity: OpportunityStatusType;
   numberVolunteers: number;
   description: string;


### PR DESCRIPTION
## Summary

- Adds `title` to `ApiOpportunityPatch` so coordinators can rename opportunities via `PATCH /opportunity/{id}`

## Context

The opportunity details profile page has a Name field that coordinators can edit. This field was wired up in fe#360 but was never functional end-to-end because `title` was missing from the patch contract — the BE schema uses `additionalProperties: false`, so any request carrying `title` would get a 400.

## Follow-up

- **BE** (`need4deed-org/be`): add `title` to `ApiVolunteerOpportunityPatch` JSON schema and map it in `parseOpportunity`
- **FE** (`need4deed-org/fe`): upgrade SDK, fold `title` into `useUpdateOpportunityDetails` (drop `useUpdateOpportunityTitle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)