### PR TITLE
fix(ci): use default GITHUB_TOKEN for checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Switching checkout to `secrets.PAT` in #152 broke the workflow — PAT is not a valid input for `actions/checkout@v4` and causes "Input required and not supplied: token".

PAT is only needed for `gh` CLI commands (already scoped to the "Open and merge" step). This reverts checkout to the implicit `GITHUB_TOKEN` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)