### PR TITLE
fix(ci): use github.token for version bump PR instead of secrets.PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Open and merge version bump PR
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           BRANCH="chore/version-bump-$VERSION"


### PR DESCRIPTION
\`secrets.PAT\` is empty/unconfigured in this repo — the \`gh\` CLI receives an empty \`GH_TOKEN\` and exits with _"To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable"_.

\`github.token\` is always available and the job already declares \`pull-requests: write\`, so it can create and merge the bump PR without needing a PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)