### PR TITLE
chore: bump version to 0.0.125

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Automated version bump triggered by merge to main. (Created manually after CI failed to open it.)