### PR TITLE
feat: redefine ApiRepresentativePatch as a proper superset of ApiPersonPatch

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -3,7 +3,7 @@ import { ApiComment } from "./comment";
 import { OptionById } from "./common";
 import { ApiLanguage } from "./language";
 import { OptionItem } from "./option";
-import { ApiPersonGet } from "./person";
+import { ApiPersonGet, ApiPersonPatch } from "./person";
 
 export enum AgentType {
   AE = "AE",
@@ -80,7 +80,15 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
   role: AgentRoleType;
 }
 
-export type ApiRepresentativePatch = VoidableProps<ApiRepresentativeGet>;
+// Superset of ApiPersonPatch: editing a person in their capacity as an
+// agent's representative additionally allows setting their role on that
+// membership. agentId disambiguates which AgentPerson row to update for a
+// person who belongs to more than one agent — it cannot be inferred from
+// personId alone.
+export type ApiRepresentativePatch = ApiPersonPatch & {
+  role?: AgentRoleType;
+  agentId?: number;
+};
 
 interface AgentGetList {
   id: number;


### PR DESCRIPTION
## Summary

Closes #158.

`ApiRepresentativeGet`/`ApiRepresentativePatch` already existed (unused anywhere in `be`) for editing a person in their capacity as an agent's representative/contact. This PR wires them up correctly for that purpose:

- `ApiRepresentativePatch` was `VoidableProps<ApiRepresentativeGet>`, which made **every** field of `ApiPersonGet` — including `id` — independently optional *and* nullable. That's broader than intended and inconsistent with `ApiPersonPatch`'s plain-optional (no `null`) semantics.
- Redefined it as `ApiPersonPatch & { role?: AgentRoleType; agentId?: number }` — a literal superset of the existing person-patch contract, plus exactly what's needed for the representative-role use case.
- Added `agentId` (optional) beyond what the issue text asked for. Per be#767 (blocked on this issue, same author, written with the fuller picture): a person can belong to more than one agent, so `be` can't reliably infer which `AgentPerson` row to update from `personId` alone — it needs `agentId` in the request. Flagged this gap and confirmed the scope with the repo owner before implementing.

## Why not touch `ApiRepresentativeGet`

It's a read-side type (`AgentGet.representative`) where `role` is always present — no change needed there; only the patch side had the shape mismatch.

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn build` passes
- No lint/test scripts configured in this repo (typecheck + build are the only checks)

## Next steps (not in this PR)

- Merging to `main` auto-publishes to npm per `.github/workflows/publish.yml` (patch bump + publish + version-bump PR, all automated).
- be#767 (blocked on this) can then consume `ApiRepresentativePatch` for `PATCH /person/:id` once the new version is on npmjs.com — per the SDK-first rule, `be` must pin to the published version, not a local link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)