### PR TITLE
chore: bump version to 0.0.126

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Automated version bump triggered by merge to main (#159). Opened manually since GitHub Actions is blocked from creating PRs in this repo — the bot's push succeeded but its own `gh pr create` step failed with 'GitHub Actions is not permitted to create or approve pull requests'.