### PR TITLE
fix: give opportunity-create form its own id-based contract

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -119,12 +119,42 @@ export interface OpportunityLegacyFormDataProps {
 export type OpportunityLegacyFormData =
   VoidableUndefined<OpportunityLegacyFormDataProps>;
 
-export type OpportunityFormDataWithAgentSubmitter = VoidableUndefined<
-  Omit<
-    OpportunityLegacyFormDataProps,
-    "rac_email" | "rac_full_name" | "rac_phone" | "rac_address" | "rac_plz"
-  >
->;
+/**
+ * Body for `POST /opportunity` — the dashboard's typed create-opportunity
+ * form. Unlike `OpportunityLegacyFormData` (free-text/ISO-code strings from
+ * the public form, resolved by title lookup), activities/skills/languages/
+ * districts here are numeric option ids from `GET /option/*`, resolved by id.
+ * Deliberately not derived from `OpportunityLegacyFormDataProps`: the two
+ * shapes look similar but mean different things, and overloading one type for
+ * both invites exactly the id-vs-title mismatch this type exists to prevent.
+ */
+export interface OpportunityCreateFormDataProps {
+  title: string;
+  agent_id?: number;
+  submitted_by_id?: number;
+  opportunity_type: OpportunityLegacyType;
+  accomp_address?: string;
+  accomp_postcode?: string;
+  accomp_datetime?: string;
+  accomp_name?: string;
+  accomp_phone?: string;
+  accomp_information?: string;
+  accomp_translation?: `${TranslatedIntoType}`;
+  districtIds?: number[];
+  languageIds: number[];
+  activityIds: number[];
+  skillIds: number[];
+  timeslots?: [number, string][];
+  onetime_date_time?: string;
+  volunteers_number: number;
+  vo_information?: string;
+  category: string;
+  category_id: OptionId;
+  last_edited_time_notion?: string;
+  language: `${Lang}`;
+}
+export type OpportunityFormDataWithAgentSubmitter =
+  VoidableUndefined<OpportunityCreateFormDataProps>;
 
 export interface ApiOpportunityAgent {
   id: number;


### PR DESCRIPTION
## Summary
- `OpportunityFormDataWithAgentSubmitter` (body of `POST /opportunity`, the dashboard create-opportunity flow) was derived from `OpportunityLegacyFormDataProps`, so `languages`/`activities`/`skills` were typed `string[]` — the same shape the legacy public form uses for title-text/ISO-code values.
- The dashboard's typed create form actually sends stringified numeric option ids through those fields (backed by `GET /option/activity|skill|language`). That type-checks against `string[]` but is semantically different, and `be` has no way to distinguish the two from the wire shape alone — this is the root cause of need4deed-org/be#774 (opportunities created from the dashboard silently lose all activities/skills/languages).
- Replaced the derived type with a standalone `OpportunityCreateFormDataProps`, with `languageIds` / `activityIds` / `skillIds` / `districtIds: number[]`. `OpportunityLegacyFormData` (the public form's contract) is untouched.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn build`
- [ ] Consumed by need4deed-org/be#774 fix and the `fe` dashboard create form once published

🤖 Generated with [Claude Code](https://claude.com/claude-code)