### PR TITLE
feat: add contacts list + create-contact contract for agent profile

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -90,6 +90,20 @@ export type ApiRepresentativePatch = ApiPersonPatch & {
   agentId?: number;
 };
 
+// Creates a brand-new contact (Person + AgentPerson membership) on an
+// existing agent — distinct from ApiAgentRegister, which always links the
+// *authenticated caller's own* person. A contact created this way need not
+// have a user account of its own. agentId is carried in the URL, not the body.
+export interface ApiAgentContactPost {
+  firstName: string;
+  lastName: string;
+  role: AgentRoleType;
+  email?: string;
+  phone?: string;
+  addressStreet?: string;
+  addressPostcode?: string;
+}
+
 interface AgentGetList {
   id: number;
   title: string;
@@ -108,6 +122,11 @@ interface AgentGet extends AgentGetList {
   updatedAt: Date;
   operator: string;
   representative: ApiRepresentativeGet;
+  // Every AgentPerson membership for this agent (representative included), so
+  // the profile can list all contacts rather than the single collapsed
+  // representative. `representative` is kept for existing consumers that only
+  // need the primary contact.
+  contacts: ApiAgentMembership[];
   serviceType: AgentServiceType[];
   statusEngagement: AgentEngagementStatusType;
   agentDetails: AgentDetails;


### PR DESCRIPTION
## Summary
Part of the multi-repo effort for need4deed-org/fe#810 (support multiple contact persons on NGO/agent profile). This is the SDK-first step per the API-contract-first policy — `be` and `fe` changes follow once this is merged and published.

- `AgentGet` gains `contacts: ApiAgentMembership[]` — every `AgentPerson` membership for the agent (representative included), reusing the existing `ApiAgentMembership` shape (`{id, agentId, agentTitle, person, role, status}`) rather than inventing a new type. `representative` is left untouched for existing consumers that only need the single primary contact (email fallback, address lookup, profile-completion flow, etc.) — this is additive, not a breaking replacement.
- New `ApiAgentContactPost` write contract for creating an additional contact (a new `Person` + `AgentPerson`) on an existing agent. This is a genuinely new backend capability — today `AgentPerson` rows are only ever created via the self-registration/join flow (`ApiAgentRegister`), always tied to the *authenticated caller's own* person. A contact added this way doesn't need a login of its own.

## Not in this PR
- No backend implementation yet (serializing `contacts`, the create-contact endpoint, auth). That's the next repo boundary — will follow once this is reviewed.
- No response-shape decision for the create endpoint beyond "reuse `ApiAgentMembership`" — the `be` PR will wrap it in the app's usual `{message, data}` envelope.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)