### PR TITLE
chore: bump version to 0.0.130

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Manually completing the automated version-bump PR that GitHub Actions couldn't open itself (repo setting blocks Actions from creating/approving PRs — see PR #166 for the full root-cause writeup).