### PR TITLE
feat: add optional isoCode to OptionItem

### DIFF
--- a/src/types/api/option.ts
+++ b/src/types/api/option.ts
@@ -4,6 +4,10 @@ import { VoidableProps } from "../utils";
 export interface OptionItem {
   title: string;
   id: number;
+  // Only ever populated for EntityTableName.LANGUAGE items — the stable
+  // ISO 639-1 code (e.g. "de", "en"), unlike `title`, which is translated
+  // into whatever language the list was requested in.
+  isoCode?: string;
 }
 
 export type ApiOptionLists = VoidableProps<


### PR DESCRIPTION
## Summary
Part of the fix for need4deed-org/fe#839 (Main communication language dropdown shows zero options — regression from #829).

Root cause traced through the stack: fe's \`getMainCommunicationLanguageOptions\` already prefers matching on \`isoCode\` over the locale-dependent \`title\` (added as review feedback on the original PR) — but \`be\`'s \`GET /option/language\` (via \`getOptions\`) never actually includes \`isoCode\` in its response, so that branch is dead code and it always falls back to matching literal \"german\"/\"english\" against a title that's always translated (e.g. \"Deutsch\"/\"Englisch\", since the caller never passes a \`language\` query param and \`be\` defaults it to German). Result: zero matches, always.

This PR adds the missing \`isoCode?: string\` field to \`OptionItem\` — only ever populated for \`LANGUAGE\` items — so \`be\` can actually supply it and \`fe\`'s existing isoCode-preferring code starts working.

## Not in this PR
- \`be\` doesn't populate \`isoCode\` yet (next repo boundary).
- \`fe\` needs no code changes at all — the isoCode-preferring branch already exists; it just needs real data.

## Test plan
- [x] \`yarn typecheck\`
- [x] \`yarn build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)