### PR TITLE
feat: extend agent contact contract for full CRUD parity

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -96,13 +96,23 @@ export type ApiRepresentativePatch = ApiPersonPatch & {
 // have a user account of its own. agentId is carried in the URL, not the body.
 export interface ApiAgentContactPost {
   firstName: string;
+  middleName?: string;
   lastName: string;
   role: AgentRoleType;
   email?: string;
   phone?: string;
+  landline?: string;
   addressStreet?: string;
   addressPostcode?: string;
 }
+
+// Updates an existing contact (Person + AgentPerson membership) on an agent.
+// Every field optional (partial update). agentId + membershipId are carried
+// in the URL, not the body — unlike ApiRepresentativePatch, which patches a
+// person by personId and disambiguates the membership via an agentId field
+// in the body, this targets one membership row directly, so it works for
+// any contact (not just a self-patch or the collapsed representative).
+export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
 
 interface AgentGetList {
   id: number;


### PR DESCRIPTION
## Summary
Part of the multi-repo effort for need4deed-org/fe#848 (unify NGO contact person rows: every contact — primary and additional — gets identical fields, display, and edit affordance).

- `ApiAgentContactPost` gains `middleName?` and `landline?`, matching the primary contact's existing edit-form field set — previously "add" and "edit" collected different shapes (add had address but no middleName/landline; edit had middleName/landline but no address). Per this issue, the resolved direction is to keep address on both and add the missing fields everywhere, so every contact (primary + additional) has the identical field set: firstName, middleName, lastName, role, email, phone, landline, addressStreet, addressPostcode.
- New `ApiAgentContactPatch` (`Partial<ApiAgentContactPost>`) for updating an *existing* contact directly by membership — distinct from `ApiRepresentativePatch`, which patches by `personId` + an `agentId` disambiguator and is gated by `be`'s `PATCH /person/:id` being strictly self-only (`authUser.personId !== personId` → 403 for anyone but ADMIN). That means today there's no way for an agent to edit a colleague's contact info at all — the new contract targets a membership row directly instead, so `be`'s upcoming endpoint can authorize it the same way `POST /agent/:id/contact` already is (any active member of that agent).

## Not in this PR
- No `be` implementation yet (next repo boundary).
- No `fe` changes (needs both `be` and this contract published first).

## Test plan
- [x] `yarn typecheck`
- [x] `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)