### PR TITLE
chore: bump version to 0.0.132

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "need4deed-sdk",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "description": "Need4Deed.org SDK",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
Manually completing the automated version-bump PR that GitHub Actions couldn't open itself (see #166 for the root-cause writeup).