### PR TITLE
Replaces string with AgentServiceType[] in AgentDetails

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -1,9 +1,9 @@
-import { Voidable, VoidableProps } from "../utils";
-import { ApiComment } from "./comment";
-import { OptionById } from "./common";
-import { ApiLanguage } from "./language";
-import { OptionItem } from "./option";
-import { ApiPersonGet, ApiPersonPatch } from "./person";
+import { Voidable, VoidableProps } from "../utils"
+import { ApiComment } from "./comment"
+import { OptionById } from "./common"
+import { ApiLanguage } from "./language"
+import { OptionItem } from "./option"
+import { ApiPersonGet, ApiPersonPatch } from "./person"
 
 export enum AgentType {
   AE = "AE",
@@ -67,17 +67,17 @@ export enum AgentTrustType {
 }
 
 export interface AgentDetails {
-  about: string;
-  website?: Voidable<string>;
-  address: string;
-  organizationType: AgentType;
-  operator: string;
-  services: string;
-  clientLanguages: OptionItem[];
+  about: string
+  website?: Voidable<string>
+  address: string
+  organizationType: AgentType
+  operator: string
+  services: AgentServiceType[]
+  clientLanguages: OptionItem[]
 }
 
 export interface ApiRepresentativeGet extends ApiPersonGet {
-  role: AgentRoleType;
+  role: AgentRoleType
 }
 
 // Superset of ApiPersonPatch: editing a person in their capacity as an
@@ -86,24 +86,24 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 // person who belongs to more than one agent — it cannot be inferred from
 // personId alone.
 export type ApiRepresentativePatch = ApiPersonPatch & {
-  role?: AgentRoleType;
-  agentId?: number;
-};
+  role?: AgentRoleType
+  agentId?: number
+}
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
 // existing agent — distinct from ApiAgentRegister, which always links the
 // *authenticated caller's own* person. A contact created this way need not
 // have a user account of its own. agentId is carried in the URL, not the body.
 export interface ApiAgentContactPost {
-  firstName: string;
-  middleName?: string;
-  lastName: string;
-  role: AgentRoleType;
-  email?: string;
-  phone?: string;
-  landline?: string;
-  addressStreet?: string;
-  addressPostcode?: string;
+  firstName: string
+  middleName?: string
+  lastName: string
+  role: AgentRoleType
+  email?: string
+  phone?: string
+  landline?: string
+  addressStreet?: string
+  addressPostcode?: string
 }
 
 // Updates an existing contact (Person + AgentPerson membership) on an agent.
@@ -112,59 +112,59 @@ export interface ApiAgentContactPost {
 // person by personId and disambiguates the membership via an agentId field
 // in the body, this targets one membership row directly, so it works for
 // any contact (not just a self-patch or the collapsed representative).
-export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
+export type ApiAgentContactPatch = Partial<ApiAgentContactPost>
 
 interface AgentGetList {
-  id: number;
-  title: string;
-  type: AgentType;
-  volunteerSearch: AgentVolunteerSearchType;
-  trustLevel: AgentTrustType;
-  district: OptionById;
-  activeVolunteers: number;
-  email: string;
-  numOpportunities: number;
+  id: number
+  title: string
+  type: AgentType
+  volunteerSearch: AgentVolunteerSearchType
+  trustLevel: AgentTrustType
+  district: OptionById
+  activeVolunteers: number
+  email: string
+  numOpportunities: number
 }
-export type ApiAgentGetList = VoidableProps<AgentGetList, "district">;
+export type ApiAgentGetList = VoidableProps<AgentGetList, "district">
 
 interface AgentGet extends AgentGetList {
-  createdAt: Date;
-  updatedAt: Date;
-  operator: string;
-  representative: ApiRepresentativeGet;
+  createdAt: Date
+  updatedAt: Date
+  operator: string
+  representative: ApiRepresentativeGet
   // Every AgentPerson membership for this agent (representative included), so
   // the profile can list all contacts rather than the single collapsed
   // representative. `representative` is kept for existing consumers that only
   // need the primary contact.
-  contacts: ApiAgentMembership[];
-  serviceType: AgentServiceType[];
-  statusEngagement: AgentEngagementStatusType;
-  agentDetails: AgentDetails;
-  comments: ApiComment[];
-  languages: ApiLanguage[];
+  contacts: ApiAgentMembership[]
+  serviceType: AgentServiceType[]
+  statusEngagement: AgentEngagementStatusType
+  agentDetails: AgentDetails
+  comments: ApiComment[]
+  languages: ApiLanguage[]
 }
 export type ApiAgentGet = VoidableProps<
   AgentGet,
   "district" | "operator" | "representative" | "serviceType" | "updatedAt"
->;
+>
 
 interface AgentPatch {
-  title: string;
-  type: AgentType;
-  volunteerSearch: AgentVolunteerSearchType;
-  trustLevel: AgentTrustType;
-  serviceType: AgentServiceType[];
-  statusEngagement: AgentEngagementStatusType;
-  about: string;
-  website: string;
-  addressStreet: string;
-  addressPostcode: string;
-  statusSearch: AgentVolunteerSearchType;
-  services: AgentServiceType[];
-  languages: OptionById[];
-  districtId: number;
+  title: string
+  type: AgentType
+  volunteerSearch: AgentVolunteerSearchType
+  trustLevel: AgentTrustType
+  serviceType: AgentServiceType[]
+  statusEngagement: AgentEngagementStatusType
+  about: string
+  website: string
+  addressStreet: string
+  addressPostcode: string
+  statusSearch: AgentVolunteerSearchType
+  services: AgentServiceType[]
+  languages: OptionById[]
+  districtId: number
 }
-export type ApiAgentPatch = VoidableProps<AgentPatch>;
+export type ApiAgentPatch = VoidableProps<AgentPatch>
 
 // --- Agent self-registration ---------------------------------------------
 // An authenticated AGENT user (already created + email-verified via POST /user)
@@ -176,20 +176,20 @@ export type ApiAgentPatch = VoidableProps<AgentPatch>;
 // different backend handlers.
 
 export interface ApiAgentRegisterNew {
-  title: string;
-  type?: AgentType;
-  info?: string;
-  website?: string;
-  services?: AgentServiceType[];
-  addressStreet?: string;
-  addressPostcode?: string;
-  districtId?: number;
-  languages?: number[];
+  title: string
+  type?: AgentType
+  info?: string
+  website?: string
+  services?: AgentServiceType[]
+  addressStreet?: string
+  addressPostcode?: string
+  districtId?: number
+  languages?: number[]
 }
 
 export type ApiAgentRegister =
   | { agentId: number }
-  | { agent: ApiAgentRegisterNew };
+  | { agent: ApiAgentRegisterNew }
 
 export enum AgentMembershipStatus {
   ACTIVE = "active",
@@ -197,36 +197,36 @@ export enum AgentMembershipStatus {
 }
 
 export interface ApiAgentRegisterResponse {
-  agentId: number;
-  membershipStatus: AgentMembershipStatus;
+  agentId: number
+  membershipStatus: AgentMembershipStatus
 }
 
 // Returned with HTTP 409 when CREATE hits the unique-title constraint, so the
 // client can offer to JOIN the existing agent instead of minting a duplicate.
 export interface ApiAgentTitleConflict {
-  conflict: "title";
-  agentId: number;
+  conflict: "title"
+  agentId: number
 }
 
 // Returned with HTTP 409 when CREATE's street+postcode already resolve to an
 // existing agent (same getAgentByAddress matcher as POST /opportunity/legacy),
 // so the client can offer to JOIN it instead of minting a duplicate.
 export interface ApiAgentAddressConflict {
-  conflict: "address";
-  agentId: number;
+  conflict: "address"
+  agentId: number
 }
 
 export type ApiAgentRegisterConflict =
   | ApiAgentTitleConflict
-  | ApiAgentAddressConflict;
+  | ApiAgentAddressConflict
 
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).
 export interface ApiAgentMembership {
-  id: number;
-  agentId: number;
-  agentTitle: string;
-  person: ApiPersonGet;
-  role: AgentRoleType;
-  status: AgentMembershipStatus;
+  id: number
+  agentId: number
+  agentTitle: string
+  person: ApiPersonGet
+  role: AgentRoleType
+  status: AgentMembershipStatus
 }

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -88,7 +88,7 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 export type ApiRepresentativePatch = ApiPersonPatch & {
   role?: AgentRoleType;
   agentId?: number;
-}
+};
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
 // existing agent — distinct from ApiAgentRegister, which always links the
@@ -112,7 +112,7 @@ export interface ApiAgentContactPost {
 // person by personId and disambiguates the membership via an agentId field
 // in the body, this targets one membership row directly, so it works for
 // any contact (not just a self-patch or the collapsed representative).
-export type ApiAgentContactPatch = Partial<ApiAgentContactPost>
+export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
 
 interface AgentGetList {
   id: number;
@@ -125,7 +125,7 @@ interface AgentGetList {
   email: string;
   numOpportunities: number;
 }
-export type ApiAgentGetList = VoidableProps<AgentGetList, "district">
+export type ApiAgentGetList = VoidableProps<AgentGetList, "district">;
 
 interface AgentGet extends AgentGetList {
   createdAt: Date;
@@ -146,7 +146,7 @@ interface AgentGet extends AgentGetList {
 export type ApiAgentGet = VoidableProps<
   AgentGet,
   "district" | "operator" | "representative" | "serviceType" | "updatedAt"
->
+>;
 
 interface AgentPatch {
   title: string;
@@ -164,7 +164,7 @@ interface AgentPatch {
   languages: OptionById[];
   districtId: number;
 }
-export type ApiAgentPatch = VoidableProps<AgentPatch>
+export type ApiAgentPatch = VoidableProps<AgentPatch>;
 
 // --- Agent self-registration ---------------------------------------------
 // An authenticated AGENT user (already created + email-verified via POST /user)
@@ -189,7 +189,7 @@ export interface ApiAgentRegisterNew {
 
 export type ApiAgentRegister =
   | { agentId: number }
-  | { agent: ApiAgentRegisterNew }
+  | { agent: ApiAgentRegisterNew };
 
 export enum AgentMembershipStatus {
   ACTIVE = "active",
@@ -218,7 +218,7 @@ export interface ApiAgentAddressConflict {
 
 export type ApiAgentRegisterConflict =
   | ApiAgentTitleConflict
-  | ApiAgentAddressConflict
+  | ApiAgentAddressConflict;
 
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -1,9 +1,9 @@
-import { Voidable, VoidableProps } from "../utils"
-import { ApiComment } from "./comment"
-import { OptionById } from "./common"
-import { ApiLanguage } from "./language"
-import { OptionItem } from "./option"
-import { ApiPersonGet, ApiPersonPatch } from "./person"
+import { Voidable, VoidableProps } from "../utils";
+import { ApiComment } from "./comment";
+import { OptionById } from "./common";
+import { ApiLanguage } from "./language";
+import { OptionItem } from "./option";
+import { ApiPersonGet, ApiPersonPatch } from "./person";
 
 export enum AgentType {
   AE = "AE",
@@ -67,17 +67,17 @@ export enum AgentTrustType {
 }
 
 export interface AgentDetails {
-  about: string
-  website?: Voidable<string>
-  address: string
-  organizationType: AgentType
-  operator: string
-  services: AgentServiceType[]
-  clientLanguages: OptionItem[]
+  about: string;
+  website?: Voidable<string>;
+  address: string;
+  organizationType: AgentType;
+  operator: string;
+  services: AgentServiceType[];
+  clientLanguages: OptionItem[];
 }
 
 export interface ApiRepresentativeGet extends ApiPersonGet {
-  role: AgentRoleType
+  role: AgentRoleType;
 }
 
 // Superset of ApiPersonPatch: editing a person in their capacity as an
@@ -86,8 +86,8 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 // person who belongs to more than one agent — it cannot be inferred from
 // personId alone.
 export type ApiRepresentativePatch = ApiPersonPatch & {
-  role?: AgentRoleType
-  agentId?: number
+  role?: AgentRoleType;
+  agentId?: number;
 }
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
@@ -95,15 +95,15 @@ export type ApiRepresentativePatch = ApiPersonPatch & {
 // *authenticated caller's own* person. A contact created this way need not
 // have a user account of its own. agentId is carried in the URL, not the body.
 export interface ApiAgentContactPost {
-  firstName: string
-  middleName?: string
-  lastName: string
-  role: AgentRoleType
-  email?: string
-  phone?: string
-  landline?: string
-  addressStreet?: string
-  addressPostcode?: string
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  role: AgentRoleType;
+  email?: string;
+  phone?: string;
+  landline?: string;
+  addressStreet?: string;
+  addressPostcode?: string;
 }
 
 // Updates an existing contact (Person + AgentPerson membership) on an agent.
@@ -115,33 +115,33 @@ export interface ApiAgentContactPost {
 export type ApiAgentContactPatch = Partial<ApiAgentContactPost>
 
 interface AgentGetList {
-  id: number
-  title: string
-  type: AgentType
-  volunteerSearch: AgentVolunteerSearchType
-  trustLevel: AgentTrustType
-  district: OptionById
-  activeVolunteers: number
-  email: string
-  numOpportunities: number
+  id: number;
+  title: string;
+  type: AgentType;
+  volunteerSearch: AgentVolunteerSearchType;
+  trustLevel: AgentTrustType;
+  district: OptionById;
+  activeVolunteers: number;
+  email: string;
+  numOpportunities: number;
 }
 export type ApiAgentGetList = VoidableProps<AgentGetList, "district">
 
 interface AgentGet extends AgentGetList {
-  createdAt: Date
-  updatedAt: Date
-  operator: string
-  representative: ApiRepresentativeGet
+  createdAt: Date;
+  updatedAt: Date;
+  operator: string;
+  representative: ApiRepresentativeGet;
   // Every AgentPerson membership for this agent (representative included), so
   // the profile can list all contacts rather than the single collapsed
   // representative. `representative` is kept for existing consumers that only
   // need the primary contact.
-  contacts: ApiAgentMembership[]
-  serviceType: AgentServiceType[]
-  statusEngagement: AgentEngagementStatusType
-  agentDetails: AgentDetails
-  comments: ApiComment[]
-  languages: ApiLanguage[]
+  contacts: ApiAgentMembership[];
+  serviceType: AgentServiceType[];
+  statusEngagement: AgentEngagementStatusType;
+  agentDetails: AgentDetails;
+  comments: ApiComment[];
+  languages: ApiLanguage[];
 }
 export type ApiAgentGet = VoidableProps<
   AgentGet,
@@ -149,20 +149,20 @@ export type ApiAgentGet = VoidableProps<
 >
 
 interface AgentPatch {
-  title: string
-  type: AgentType
-  volunteerSearch: AgentVolunteerSearchType
-  trustLevel: AgentTrustType
-  serviceType: AgentServiceType[]
-  statusEngagement: AgentEngagementStatusType
-  about: string
-  website: string
-  addressStreet: string
-  addressPostcode: string
-  statusSearch: AgentVolunteerSearchType
-  services: AgentServiceType[]
-  languages: OptionById[]
-  districtId: number
+  title: string;
+  type: AgentType;
+  volunteerSearch: AgentVolunteerSearchType;
+  trustLevel: AgentTrustType;
+  serviceType: AgentServiceType[];
+  statusEngagement: AgentEngagementStatusType;
+  about: string;
+  website: string;
+  addressStreet: string;
+  addressPostcode: string;
+  statusSearch: AgentVolunteerSearchType;
+  services: AgentServiceType[];
+  languages: OptionById[];
+  districtId: number;
 }
 export type ApiAgentPatch = VoidableProps<AgentPatch>
 
@@ -176,15 +176,15 @@ export type ApiAgentPatch = VoidableProps<AgentPatch>
 // different backend handlers.
 
 export interface ApiAgentRegisterNew {
-  title: string
-  type?: AgentType
-  info?: string
-  website?: string
-  services?: AgentServiceType[]
-  addressStreet?: string
-  addressPostcode?: string
-  districtId?: number
-  languages?: number[]
+  title: string;
+  type?: AgentType;
+  info?: string;
+  website?: string;
+  services?: AgentServiceType[];
+  addressStreet?: string;
+  addressPostcode?: string;
+  districtId?: number;
+  languages?: number[];
 }
 
 export type ApiAgentRegister =
@@ -197,23 +197,23 @@ export enum AgentMembershipStatus {
 }
 
 export interface ApiAgentRegisterResponse {
-  agentId: number
-  membershipStatus: AgentMembershipStatus
+  agentId: number;
+  membershipStatus: AgentMembershipStatus;
 }
 
 // Returned with HTTP 409 when CREATE hits the unique-title constraint, so the
 // client can offer to JOIN the existing agent instead of minting a duplicate.
 export interface ApiAgentTitleConflict {
-  conflict: "title"
-  agentId: number
+  conflict: "title";
+  agentId: number;
 }
 
 // Returned with HTTP 409 when CREATE's street+postcode already resolve to an
 // existing agent (same getAgentByAddress matcher as POST /opportunity/legacy),
 // so the client can offer to JOIN it instead of minting a duplicate.
 export interface ApiAgentAddressConflict {
-  conflict: "address"
-  agentId: number
+  conflict: "address";
+  agentId: number;
 }
 
 export type ApiAgentRegisterConflict =
@@ -223,10 +223,10 @@ export type ApiAgentRegisterConflict =
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).
 export interface ApiAgentMembership {
-  id: number
-  agentId: number
-  agentTitle: string
-  person: ApiPersonGet
-  role: AgentRoleType
-  status: AgentMembershipStatus
+  id: number;
+  agentId: number;
+  agentTitle: string;
+  person: ApiPersonGet;
+  role: AgentRoleType;
+  status: AgentMembershipStatus;
 }


### PR DESCRIPTION
## Description
In `agent` for `services` the type is `string` when it should be `AgentServiceType[]` as evident in the `ApiAgentRegisterNew interface` and `AgentPatch` 

## Related Issues
related to [#843 in `fe`](https://github.com/need4deed-org/fe/issues/843)

## Changes
Changes type for `services` in `AgentDetails` from `string` to `AgentServiceType[]`

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

