### PR TITLE
refactor: rename AgentType enum to AgentTypeKey

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -5,7 +5,7 @@ import { ApiLanguage } from "./language";
 import { OptionItem } from "./option";
 import { ApiPersonGet, ApiPersonPatch } from "./person";
 
-export enum AgentType {
+export enum AgentTypeKey {
   AE = "AE",
   GU1 = "GU1",
   GU2 = "GU2",
@@ -70,7 +70,7 @@ export interface AgentDetails {
   about: string;
   website?: Voidable<string>;
   address: string;
-  organizationType: AgentType;
+  organizationType: AgentTypeKey;
   operator: string;
   services: string;
   clientLanguages: OptionItem[];
@@ -117,7 +117,7 @@ export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
 interface AgentGetList {
   id: number;
   title: string;
-  type: AgentType;
+  type: AgentTypeKey;
   volunteerSearch: AgentVolunteerSearchType;
   trustLevel: AgentTrustType;
   district: OptionById;
@@ -150,7 +150,7 @@ export type ApiAgentGet = VoidableProps<
 
 interface AgentPatch {
   title: string;
-  type: AgentType;
+  type: AgentTypeKey;
   volunteerSearch: AgentVolunteerSearchType;
   trustLevel: AgentTrustType;
   serviceType: AgentServiceType[];
@@ -177,7 +177,7 @@ export type ApiAgentPatch = VoidableProps<AgentPatch>;
 
 export interface ApiAgentRegisterNew {
   title: string;
-  type?: AgentType;
+  type?: AgentTypeKey;
   info?: string;
   website?: string;
   services?: AgentServiceType[];

--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -1,6 +1,6 @@
 import { Id, Lang, VoidableProps, VoidableUndefined } from "..";
 import { ApiOpportunityAccompanyingDetails } from "./accompanying";
-import { AgentType } from "./agent";
+import { AgentTypeKey } from "./agent";
 import { ApiComment } from "./comment";
 import { OptionById, OptionId } from "./common";
 import { ApiLanguage } from "./language";
@@ -158,7 +158,7 @@ export type OpportunityFormDataWithAgentSubmitter =
 
 export interface ApiOpportunityAgent {
   id: number;
-  type: AgentType;
+  type: AgentTypeKey;
   name: string;
   address: string;
   district: OptionById;


### PR DESCRIPTION
## Summary
- Renames the `AgentType` enum to `AgentTypeKey` across `src/types/api/agent.ts` and its usage in `src/types/api/opportunity.ts`.
- Frees up the `AgentType` name for the upcoming translated reference-data type (`{ id, title: { en, de } }`) described in #177, which will replace the raw enum on `Agent.type`.
- No other behavior change; this is a pure rename (6 usages: the enum declaration plus `AgentDetails.organizationType`, `AgentGetList.type`, `AgentPatch.type`, `ApiAgentRegisterNew.type`, `ApiOpportunityAgent.type`).

## Test plan
- [x] `yarn build` (tsc) passes
- [x] Confirmed no remaining bare `AgentType` references in `src/`
- [ ] Version bump + npm publish deferred until the rest of #177's contract work lands, to avoid publishing an intermediate/partial state

Part of #177.