### PR TITLE
feat: add 4 volunteer appreciation options

### DIFF
--- a/src/types/api/volunteer.ts
+++ b/src/types/api/volunteer.ts
@@ -85,6 +85,10 @@ export enum VolunteerStateAppreciationType {
   T_SHIRT = "t-shirt",
   BENEFIT_CARD = "benefit-card",
   TOTE_BAG = "tote-bag",
+  NEED4DEED_CERTIFICATE = "need4deed-certificate",
+  CAP = "cap",
+  NOTEBOOK = "notebook",
+  CITY_CERTIFICATE = "city-certificate",
 }
 
 export const VolunteerStateTypeType = ProfileVolunteeringType;


### PR DESCRIPTION
## Summary
Adds four new values to `VolunteerStateAppreciationType`: `NEED4DEED_CERTIFICATE`, `CAP`, `NOTEBOOK`, `CITY_CERTIFICATE`.

Contract change requested by need4deed-org/be#795 (volunteer appreciation picklist expansion). No other type changes needed — `Appreciation.title` and `Volunteer.statusAppreciation` in `be` already spread this enum directly via entity decorators.

## Test plan
- [x] `yarn typecheck` passes
- [ ] Merge to `main` → CI auto-bumps patch version and publishes to npm
- [ ] `be` bumps `need4deed-sdk` dependency and generates a migration for the two backing Postgres enum types