### PR TITLE
feat: add OpportunitySortField enum for server-side event/appointment sorting

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -45,6 +45,11 @@ export enum OpportunityMatchStatusType {
   PAST = "opp-vol-past",
 }
 
+export enum OpportunitySortField {
+  CREATED_AT = "created-at",
+  START_DATE = "start-date",
+}
+
 export enum OpportunityMatchStatus {
   NO_MATCHES = "vol-no-matches",
   PENDING_MATCH = "vol-pending-match",


### PR DESCRIPTION
## Summary
- Adds `OpportunitySortField` enum (`CREATED_AT` / `START_DATE`) to `src/types/api/opportunity.ts`, purely additive.
- Supports need4deed-org/be#746: server-side sorting of opportunities by appointment/event start date instead of only `createdAt`, replacing the current client-side-per-page sort.
- `SortOrder` is left untouched (stays a pure direction enum, shared with the agent-list endpoint) — the new enum is a separate field selector, scoped to opportunities only.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn build` passes
- [ ] Consumed and exercised by need4deed-org/be#746 implementation branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)