### PR TITLE
feat: narrow ApiOpportunityPatch.contact to relink-only { id }

### DIFF
--- a/src/types/api/opportunity.ts
+++ b/src/types/api/opportunity.ts
@@ -231,11 +231,14 @@ export type ApiOpportunityPatch = VoidableProps<{
     time: string;
   };
   contact: {
+    /**
+     * Relinks the opportunity to a different Person already registered as a
+     * contact of the opportunity's agent. `name`/`phone`/`email`/
+     * `waysToContact` are derived from that Person and returned on
+     * `ApiOpportunityContact` — editing them directly goes through the
+     * agent-contact endpoints (`ApiAgentContactPatch`), not this field.
+     */
     id: number;
-    name: string;
-    phone: string;
-    email: string;
-    waysToContact: PreferredCommunicationType[];
   };
   agent: {
     id?: number;


### PR DESCRIPTION
## What

Narrows `ApiOpportunityPatch.contact` from the full `{ id, name, phone, email, waysToContact }` shape to relink-only `{ id }`.

## Why

fe#893 turned the opportunity Contact Person field into a picker over the agent's registered contacts — it only ever needs to say *which* Person is the contact, never edit that Person's own fields. The read shape (`ApiOpportunityContact`, returned on `GET`) is unchanged; only the PATCH input narrows.

Editing a contact's own name/phone/email/waysToContact should go through the agent-contact endpoints instead of `PATCH /opportunity/:id` — see be#824 for why: today that route actually persists those fields onto whichever Person happens to be linked (a shared row that could be an agent representative), which is a separate concern from relinking.

## Not in scope here

- Implementing the actual relink in `be` (tracked in be#824 — bare `{ id }` today is a no-op there).
- Removing the now-stale `contact.name/phone/email/waysToContact` reads in `be`'s `parser-opportunity-patch-data.ts` — that becomes a compile error once `be` upgrades past this version, which is deliberate: it points straight at what needs to change for be#824.

**Please don't merge until `be#824` is ready to pick this up** — this repo auto-publishes to npm and bumps the version on every merge to `main`.

Closes #187