### PR TITLE
feat: add agentMemberships to /me response for multi-agent users (be#809)

### DIFF
--- a/src/types/api/user.ts
+++ b/src/types/api/user.ts
@@ -22,6 +22,16 @@ export interface ApiUserPost {
   };
 }
 
+// Deliberately not ApiAgentMembership (that one embeds a full ApiPersonGet —
+// meant for "who are this agent's contacts", the opposite direction, and
+// would over-expose PII for what /me needs). Not OptionById either — agent
+// titles are a plain string, not the per-locale OptionTitle map that type
+// expects. be#809.
+export interface ApiAgentMembershipSummary {
+  agentId: number;
+  agentTitle: string;
+}
+
 interface UserGet {
   id: number;
   personId: number;
@@ -33,7 +43,13 @@ interface UserGet {
   avatarUrl: string;
   isoCode: string;
   timezone: string;
+  // Single "primary" active agent membership — kept for backward
+  // compatibility with existing single-agent consumers. See
+  // agentMemberships for the full list (be#809).
   agentId?: number;
+  // All of the caller's active AgentPerson memberships, not just one — a
+  // person can belong to more than one agent (be#809).
+  agentMemberships?: ApiAgentMembershipSummary[];
 }
 
 export type ApiUserGet = VoidableProps<UserGet, "avatarUrl" | "personId">;


### PR DESCRIPTION
## Summary

`GET /me` only ever returned a single `agentId`, even though the data model already supports a person holding more than one active `AgentPerson` membership (unique index is on `(agentId, personId, role)`, not `personId` alone). This blocks users who work at more than one NGO from seeing/switching to their other org.

Part of the fix for need4deed-org/be#809 — SDK-first per project convention, `be` and `fe` follow once this is published.

## Changes

- New `ApiAgentMembershipSummary { agentId: number; agentTitle: string }`.
- `UserGet` (→ `ApiUserGet`) gains `agentMemberships?: ApiAgentMembershipSummary[]`, additive alongside the existing `agentId?: number` (kept as-is for backward compatibility with single-agent consumers — be#809's acceptance criteria requires existing single-agent users to keep resolving correctly with one entry).

### Why a new type instead of reusing an existing one

- **`ApiAgentMembership`** (used in `AgentGet.contacts`) embeds a full `ApiPersonGet` — that's the *agent's* list of its own contacts (agent → people), the opposite direction from what `/me` needs (person → their agents), and would force populating the caller's own person data redundantly on every membership row.
- **`OptionById`** doesn't fit either — its `title` is the per-locale `OptionTitle` map, but agent titles are a plain `string` (see `Agent.title` on the `be` side).

## Test plan

- [x] `yarn typecheck` clean
- [x] `yarn build` clean
- [x] `prettier --check` clean on the changed file
- No test suite exists in this repo (type-definitions-only package).

## Note on merging

This repo auto-publishes to npm on every push to `main` (`.github/workflows/publish.yml` bumps the patch version and runs `yarn publish` on merge). Flagging explicitly since that's a real, external, one-way action — merge when ready for `0.0.140` to go live, not before `be`/`fe` are ready to consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
