### PR TITLE
FE 796: Adds incontact & tried_to_contact to AgentEngagementStatus

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -74,8 +74,8 @@ export enum AgentTrustType {
 
 // Translated reference data: an id resolving to an en/de title via
 // field_translation, rather than a bare enum value.
-export type AgentType = OptionById
-export type Service = OptionById
+export type AgentType = OptionById;
+export type Service = OptionById;
 
 export interface AgentDetails {
   about: string;
@@ -99,7 +99,7 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 export type ApiRepresentativePatch = ApiPersonPatch & {
   role?: AgentRoleType;
   agentId?: number;
-}
+};
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
 // existing agent — distinct from ApiAgentRegister, which always links the

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -1,9 +1,9 @@
-import { Voidable, VoidableProps } from "../utils";
-import { ApiComment } from "./comment";
-import { OptionById } from "./common";
-import { ApiLanguage } from "./language";
-import { OptionItem } from "./option";
-import { ApiPersonGet, ApiPersonPatch } from "./person";
+import { Voidable, VoidableProps } from "../utils"
+import { ApiComment } from "./comment"
+import { OptionById } from "./common"
+import { ApiLanguage } from "./language"
+import { OptionItem } from "./option"
+import { ApiPersonGet, ApiPersonPatch } from "./person"
 
 // Canonical seed values for the `agent_type` reference table (see AgentType
 // below) — not used directly in any API contract.
@@ -41,6 +41,8 @@ export enum AgentEngagementStatusType {
   ACTIVE = "agent-active",
   UNRESPONSIVE = "agent-unresponsive",
   INACTIVE = "agent-inactive",
+  INCONTACT = "agent-incontact",
+  TRIED_TO_CONTACT = "agent-tried-to-contact",
 }
 
 export enum AgentVolunteerSearchType {
@@ -72,21 +74,21 @@ export enum AgentTrustType {
 
 // Translated reference data: an id resolving to an en/de title via
 // field_translation, rather than a bare enum value.
-export type AgentType = OptionById;
-export type Service = OptionById;
+export type AgentType = OptionById
+export type Service = OptionById
 
 export interface AgentDetails {
-  about: string;
-  website?: Voidable<string>;
-  address: string;
-  organizationType: AgentType;
-  operator: string;
-  services: Service[];
-  clientLanguages: OptionItem[];
+  about: string
+  website?: Voidable<string>
+  address: string
+  organizationType: AgentType
+  operator: string
+  services: Service[]
+  clientLanguages: OptionItem[]
 }
 
 export interface ApiRepresentativeGet extends ApiPersonGet {
-  role: AgentRoleType;
+  role: AgentRoleType
 }
 
 // Superset of ApiPersonPatch: editing a person in their capacity as an
@@ -95,24 +97,24 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 // person who belongs to more than one agent — it cannot be inferred from
 // personId alone.
 export type ApiRepresentativePatch = ApiPersonPatch & {
-  role?: AgentRoleType;
-  agentId?: number;
-};
+  role?: AgentRoleType
+  agentId?: number
+}
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
 // existing agent — distinct from ApiAgentRegister, which always links the
 // *authenticated caller's own* person. A contact created this way need not
 // have a user account of its own. agentId is carried in the URL, not the body.
 export interface ApiAgentContactPost {
-  firstName: string;
-  middleName?: string;
-  lastName: string;
-  role: AgentRoleType;
-  email?: string;
-  phone?: string;
-  landline?: string;
-  addressStreet?: string;
-  addressPostcode?: string;
+  firstName: string
+  middleName?: string
+  lastName: string
+  role: AgentRoleType
+  email?: string
+  phone?: string
+  landline?: string
+  addressStreet?: string
+  addressPostcode?: string
 }
 
 // Updates an existing contact (Person + AgentPerson membership) on an agent.
@@ -121,58 +123,58 @@ export interface ApiAgentContactPost {
 // person by personId and disambiguates the membership via an agentId field
 // in the body, this targets one membership row directly, so it works for
 // any contact (not just a self-patch or the collapsed representative).
-export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
+export type ApiAgentContactPatch = Partial<ApiAgentContactPost>
 
 interface AgentGetList {
-  id: number;
-  title: string;
-  type: AgentType;
-  volunteerSearch: AgentVolunteerSearchType;
-  trustLevel: AgentTrustType;
-  district: OptionById;
-  activeVolunteers: number;
-  email: string;
-  numOpportunities: number;
+  id: number
+  title: string
+  type: AgentType
+  volunteerSearch: AgentVolunteerSearchType
+  trustLevel: AgentTrustType
+  district: OptionById
+  activeVolunteers: number
+  email: string
+  numOpportunities: number
 }
-export type ApiAgentGetList = VoidableProps<AgentGetList, "district">;
+export type ApiAgentGetList = VoidableProps<AgentGetList, "district">
 
 interface AgentGet extends AgentGetList {
-  createdAt: Date;
-  updatedAt: Date;
-  operator: string;
-  representative: ApiRepresentativeGet;
+  createdAt: Date
+  updatedAt: Date
+  operator: string
+  representative: ApiRepresentativeGet
   // Every AgentPerson membership for this agent (representative included), so
   // the profile can list all contacts rather than the single collapsed
   // representative. `representative` is kept for existing consumers that only
   // need the primary contact.
-  contacts: ApiAgentMembership[];
-  services: Service[];
-  statusEngagement: AgentEngagementStatusType;
-  agentDetails: AgentDetails;
-  comments: ApiComment[];
-  languages: ApiLanguage[];
+  contacts: ApiAgentMembership[]
+  services: Service[]
+  statusEngagement: AgentEngagementStatusType
+  agentDetails: AgentDetails
+  comments: ApiComment[]
+  languages: ApiLanguage[]
 }
 export type ApiAgentGet = VoidableProps<
   AgentGet,
   "district" | "operator" | "representative" | "services" | "updatedAt"
->;
+>
 
 interface AgentPatch {
-  title: string;
-  typeId: number;
-  volunteerSearch: AgentVolunteerSearchType;
-  trustLevel: AgentTrustType;
-  statusEngagement: AgentEngagementStatusType;
-  about: string;
-  website: string;
-  addressStreet: string;
-  addressPostcode: string;
-  statusSearch: AgentVolunteerSearchType;
-  serviceIds: number[];
-  languages: OptionById[];
-  districtId: number;
+  title: string
+  typeId: number
+  volunteerSearch: AgentVolunteerSearchType
+  trustLevel: AgentTrustType
+  statusEngagement: AgentEngagementStatusType
+  about: string
+  website: string
+  addressStreet: string
+  addressPostcode: string
+  statusSearch: AgentVolunteerSearchType
+  serviceIds: number[]
+  languages: OptionById[]
+  districtId: number
 }
-export type ApiAgentPatch = VoidableProps<AgentPatch>;
+export type ApiAgentPatch = VoidableProps<AgentPatch>
 
 // --- Agent self-registration ---------------------------------------------
 // An authenticated AGENT user (already created + email-verified via POST /user)
@@ -184,20 +186,20 @@ export type ApiAgentPatch = VoidableProps<AgentPatch>;
 // different backend handlers.
 
 export interface ApiAgentRegisterNew {
-  title: string;
-  typeId?: number;
-  info?: string;
-  website?: string;
-  serviceIds?: number[];
-  addressStreet?: string;
-  addressPostcode?: string;
-  districtId?: number;
-  languages?: number[];
+  title: string
+  typeId?: number
+  info?: string
+  website?: string
+  serviceIds?: number[]
+  addressStreet?: string
+  addressPostcode?: string
+  districtId?: number
+  languages?: number[]
 }
 
 export type ApiAgentRegister =
   | { agentId: number }
-  | { agent: ApiAgentRegisterNew };
+  | { agent: ApiAgentRegisterNew }
 
 export enum AgentMembershipStatus {
   ACTIVE = "active",
@@ -205,36 +207,36 @@ export enum AgentMembershipStatus {
 }
 
 export interface ApiAgentRegisterResponse {
-  agentId: number;
-  membershipStatus: AgentMembershipStatus;
+  agentId: number
+  membershipStatus: AgentMembershipStatus
 }
 
 // Returned with HTTP 409 when CREATE hits the unique-title constraint, so the
 // client can offer to JOIN the existing agent instead of minting a duplicate.
 export interface ApiAgentTitleConflict {
-  conflict: "title";
-  agentId: number;
+  conflict: "title"
+  agentId: number
 }
 
 // Returned with HTTP 409 when CREATE's street+postcode already resolve to an
 // existing agent (same getAgentByAddress matcher as POST /opportunity/legacy),
 // so the client can offer to JOIN it instead of minting a duplicate.
 export interface ApiAgentAddressConflict {
-  conflict: "address";
-  agentId: number;
+  conflict: "address"
+  agentId: number
 }
 
 export type ApiAgentRegisterConflict =
   | ApiAgentTitleConflict
-  | ApiAgentAddressConflict;
+  | ApiAgentAddressConflict
 
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).
 export interface ApiAgentMembership {
-  id: number;
-  agentId: number;
-  agentTitle: string;
-  person: ApiPersonGet;
-  role: AgentRoleType;
-  status: AgentMembershipStatus;
+  id: number
+  agentId: number
+  agentTitle: string
+  person: ApiPersonGet
+  role: AgentRoleType
+  status: AgentMembershipStatus
 }

--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -1,9 +1,9 @@
-import { Voidable, VoidableProps } from "../utils"
-import { ApiComment } from "./comment"
-import { OptionById } from "./common"
-import { ApiLanguage } from "./language"
-import { OptionItem } from "./option"
-import { ApiPersonGet, ApiPersonPatch } from "./person"
+import { Voidable, VoidableProps } from "../utils";
+import { ApiComment } from "./comment";
+import { OptionById } from "./common";
+import { ApiLanguage } from "./language";
+import { OptionItem } from "./option";
+import { ApiPersonGet, ApiPersonPatch } from "./person";
 
 // Canonical seed values for the `agent_type` reference table (see AgentType
 // below) — not used directly in any API contract.
@@ -78,17 +78,17 @@ export type AgentType = OptionById
 export type Service = OptionById
 
 export interface AgentDetails {
-  about: string
-  website?: Voidable<string>
-  address: string
-  organizationType: AgentType
-  operator: string
-  services: Service[]
-  clientLanguages: OptionItem[]
+  about: string;
+  website?: Voidable<string>;
+  address: string;
+  organizationType: AgentType;
+  operator: string;
+  services: Service[];
+  clientLanguages: OptionItem[];
 }
 
 export interface ApiRepresentativeGet extends ApiPersonGet {
-  role: AgentRoleType
+  role: AgentRoleType;
 }
 
 // Superset of ApiPersonPatch: editing a person in their capacity as an
@@ -97,8 +97,8 @@ export interface ApiRepresentativeGet extends ApiPersonGet {
 // person who belongs to more than one agent — it cannot be inferred from
 // personId alone.
 export type ApiRepresentativePatch = ApiPersonPatch & {
-  role?: AgentRoleType
-  agentId?: number
+  role?: AgentRoleType;
+  agentId?: number;
 }
 
 // Creates a brand-new contact (Person + AgentPerson membership) on an
@@ -106,15 +106,15 @@ export type ApiRepresentativePatch = ApiPersonPatch & {
 // *authenticated caller's own* person. A contact created this way need not
 // have a user account of its own. agentId is carried in the URL, not the body.
 export interface ApiAgentContactPost {
-  firstName: string
-  middleName?: string
-  lastName: string
-  role: AgentRoleType
-  email?: string
-  phone?: string
-  landline?: string
-  addressStreet?: string
-  addressPostcode?: string
+  firstName: string;
+  middleName?: string;
+  lastName: string;
+  role: AgentRoleType;
+  email?: string;
+  phone?: string;
+  landline?: string;
+  addressStreet?: string;
+  addressPostcode?: string;
 }
 
 // Updates an existing contact (Person + AgentPerson membership) on an agent.
@@ -123,58 +123,58 @@ export interface ApiAgentContactPost {
 // person by personId and disambiguates the membership via an agentId field
 // in the body, this targets one membership row directly, so it works for
 // any contact (not just a self-patch or the collapsed representative).
-export type ApiAgentContactPatch = Partial<ApiAgentContactPost>
+export type ApiAgentContactPatch = Partial<ApiAgentContactPost>;
 
 interface AgentGetList {
-  id: number
-  title: string
-  type: AgentType
-  volunteerSearch: AgentVolunteerSearchType
-  trustLevel: AgentTrustType
-  district: OptionById
-  activeVolunteers: number
-  email: string
-  numOpportunities: number
+  id: number;
+  title: string;
+  type: AgentType;
+  volunteerSearch: AgentVolunteerSearchType;
+  trustLevel: AgentTrustType;
+  district: OptionById;
+  activeVolunteers: number;
+  email: string;
+  numOpportunities: number;
 }
-export type ApiAgentGetList = VoidableProps<AgentGetList, "district">
+export type ApiAgentGetList = VoidableProps<AgentGetList, "district">;
 
 interface AgentGet extends AgentGetList {
-  createdAt: Date
-  updatedAt: Date
-  operator: string
-  representative: ApiRepresentativeGet
+  createdAt: Date;
+  updatedAt: Date;
+  operator: string;
+  representative: ApiRepresentativeGet;
   // Every AgentPerson membership for this agent (representative included), so
   // the profile can list all contacts rather than the single collapsed
   // representative. `representative` is kept for existing consumers that only
   // need the primary contact.
-  contacts: ApiAgentMembership[]
-  services: Service[]
-  statusEngagement: AgentEngagementStatusType
-  agentDetails: AgentDetails
-  comments: ApiComment[]
-  languages: ApiLanguage[]
+  contacts: ApiAgentMembership[];
+  services: Service[];
+  statusEngagement: AgentEngagementStatusType;
+  agentDetails: AgentDetails;
+  comments: ApiComment[];
+  languages: ApiLanguage[];
 }
 export type ApiAgentGet = VoidableProps<
   AgentGet,
   "district" | "operator" | "representative" | "services" | "updatedAt"
->
+>;
 
 interface AgentPatch {
-  title: string
-  typeId: number
-  volunteerSearch: AgentVolunteerSearchType
-  trustLevel: AgentTrustType
-  statusEngagement: AgentEngagementStatusType
-  about: string
-  website: string
-  addressStreet: string
-  addressPostcode: string
-  statusSearch: AgentVolunteerSearchType
-  serviceIds: number[]
-  languages: OptionById[]
-  districtId: number
+  title: string;
+  typeId: number;
+  volunteerSearch: AgentVolunteerSearchType;
+  trustLevel: AgentTrustType;
+  statusEngagement: AgentEngagementStatusType;
+  about: string;
+  website: string;
+  addressStreet: string;
+  addressPostcode: string;
+  statusSearch: AgentVolunteerSearchType;
+  serviceIds: number[];
+  languages: OptionById[];
+  districtId: number;
 }
-export type ApiAgentPatch = VoidableProps<AgentPatch>
+export type ApiAgentPatch = VoidableProps<AgentPatch>;
 
 // --- Agent self-registration ---------------------------------------------
 // An authenticated AGENT user (already created + email-verified via POST /user)
@@ -186,20 +186,20 @@ export type ApiAgentPatch = VoidableProps<AgentPatch>
 // different backend handlers.
 
 export interface ApiAgentRegisterNew {
-  title: string
-  typeId?: number
-  info?: string
-  website?: string
-  serviceIds?: number[]
-  addressStreet?: string
-  addressPostcode?: string
-  districtId?: number
-  languages?: number[]
+  title: string;
+  typeId?: number;
+  info?: string;
+  website?: string;
+  serviceIds?: number[];
+  addressStreet?: string;
+  addressPostcode?: string;
+  districtId?: number;
+  languages?: number[];
 }
 
 export type ApiAgentRegister =
   | { agentId: number }
-  | { agent: ApiAgentRegisterNew }
+  | { agent: ApiAgentRegisterNew };
 
 export enum AgentMembershipStatus {
   ACTIVE = "active",
@@ -207,36 +207,36 @@ export enum AgentMembershipStatus {
 }
 
 export interface ApiAgentRegisterResponse {
-  agentId: number
-  membershipStatus: AgentMembershipStatus
+  agentId: number;
+  membershipStatus: AgentMembershipStatus;
 }
 
 // Returned with HTTP 409 when CREATE hits the unique-title constraint, so the
 // client can offer to JOIN the existing agent instead of minting a duplicate.
 export interface ApiAgentTitleConflict {
-  conflict: "title"
-  agentId: number
+  conflict: "title";
+  agentId: number;
 }
 
 // Returned with HTTP 409 when CREATE's street+postcode already resolve to an
 // existing agent (same getAgentByAddress matcher as POST /opportunity/legacy),
 // so the client can offer to JOIN it instead of minting a duplicate.
 export interface ApiAgentAddressConflict {
-  conflict: "address"
-  agentId: number
+  conflict: "address";
+  agentId: number;
 }
 
 export type ApiAgentRegisterConflict =
   | ApiAgentTitleConflict
-  | ApiAgentAddressConflict
+  | ApiAgentAddressConflict;
 
 // A person<->agent membership, surfaced to ADMIN/COORDINATOR for moderating
 // joins that did not pass domain-match (membershipStatus === PENDING).
 export interface ApiAgentMembership {
-  id: number
-  agentId: number
-  agentTitle: string
-  person: ApiPersonGet
-  role: AgentRoleType
-  status: AgentMembershipStatus
+  id: number;
+  agentId: number;
+  agentTitle: string;
+  person: ApiPersonGet;
+  role: AgentRoleType;
+  status: AgentMembershipStatus;
 }


### PR DESCRIPTION
## Description
Adds two new enum types to `AgentEngagementStatus`:
- Tried to contact
- In contact 

## Related Issues
Addresses `fe`  [Issue 796](https://github.com/need4deed-org/fe/issues/796)

## Changes
- Bullet list of meaningful changes (optional)

## Screenshots / Demos
If UI-related, add before/after or GIFs.

## Checklist
- [ ] WITHIN THE SCOPE OF AN ISSUE; No unnecessary files included
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] CI passes

