### PR TITLE
feat: add organizationId to AgentPatch and ApiOrganizationGetList

### DIFF
--- a/src/types/api/agent.ts
+++ b/src/types/api/agent.ts
@@ -173,6 +173,7 @@ interface AgentPatch {
   serviceIds: number[];
   languages: OptionById[];
   districtId: number;
+  organizationId: number;
 }
 export type ApiAgentPatch = VoidableProps<AgentPatch>;
 

--- a/src/types/api/organization.ts
+++ b/src/types/api/organization.ts
@@ -8,3 +8,13 @@ export interface ApiOrganizationGet {
 }
 
 export type ApiOrganizationPatch = Partial<ApiOrganizationGet>;
+
+// Dropdown row for picking an agent's operator (Träger), e.g. IB/DRK/Albatros
+// (be#843). Deliberately its own minimal shape rather than ApiOrganizationGet:
+// a picker list has no use for website/address, and organizations aren't
+// translated reference data, so this doesn't go through the generic
+// EntityTableName/ApiOptionLists mechanism used by Skill/Language/Activity.
+export interface ApiOrganizationGetList {
+  id: number;
+  title: string;
+}

--- a/src/types/api/organization.ts
+++ b/src/types/api/organization.ts
@@ -10,11 +10,9 @@ export interface ApiOrganizationGet {
 export type ApiOrganizationPatch = Partial<ApiOrganizationGet>;
 
 // Dropdown row for picking an agent's operator (Träger), e.g. IB/DRK/Albatros
-// (be#843). Deliberately its own minimal shape rather than ApiOrganizationGet:
-// a picker list has no use for website/address, and organizations aren't
-// translated reference data, so this doesn't go through the generic
+// (be#843). Picked from ApiOrganizationGet rather than hand-duplicated, so it
+// can't drift from the canonical shape (see AgentGetList/AgentGet in
+// agent.ts for the same derive-from-canonical convention). Organizations
+// aren't translated reference data, so this doesn't go through the generic
 // EntityTableName/ApiOptionLists mechanism used by Skill/Language/Activity.
-export interface ApiOrganizationGetList {
-  id: number;
-  title: string;
-}
+export type ApiOrganizationGetList = Pick<ApiOrganizationGet, "id" | "title">;


### PR DESCRIPTION
## Summary

Closes #186. Companion SDK change for need4deed-org/be#843.

`Agent.organizationId` already exists as a column/relation on the `be` entity (`src/data/entity/opportunity/agent.entity.ts`) — the dashboard's "Operator" (Träger, e.g. IB/DRK/Albatros) field is backed by it — but the field was never part of the `AgentPatch` contract, so edits to it were silently dropped by `be`'s `parseAgentPatch()`. Confirmed against current `be` code in be#843.

## Changes

- `AgentPatch.organizationId: number` — mirrors the existing scalar-id convention already used for `typeId`/`districtId` on the same interface.
- `ApiOrganizationGetList { id, title }` — a minimal dropdown-row type so `fe` can list existing organizations to populate the operator picker. Kept as its own dedicated type in `organization.ts` rather than routed through the generic `EntityTableName`/`ApiOptionLists` mechanism used by Skill/Language/Activity, since organizations aren't translated reference data and threading them through the `FieldTranslation` join would be unwarranted complexity for a plain id+title list.

## Scope

Per be#843, `be` will need to: bump this SDK version once published, map `organizationId` in `parseAgentPatch()`, and add a `GET /organization` list route returning `ApiOrganizationGetList[]`. `fe`'s dropdown wiring is tracked separately in fe#885.

## Test plan

- [x] `yarn typecheck`
- [x] `yarn build`